### PR TITLE
Fix accessories being removed on Homebridge restart

### DIFF
--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -116,7 +116,7 @@ export class CameraAccessory {
     const name = `${this.accessory.displayName} - Eyes`;
     this.privacyService = this.accessory.getService(name);
     if (!this.privacyService) {
-      this.log.debug("Adding alert service");
+      this.log.debug("Adding privacy service");
       this.privacyService = this.accessory.addService(
         this.api.hap.Service.Switch,
         name,

--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -62,7 +62,12 @@ export class CameraAccessory {
   ) {
     this.infoAccessory = this.accessory.getService(
       this.api.hap.Service.AccessoryInformation
-    )!;
+    );
+    if (!this.infoAccessory) {
+      this.log.debug("Adding accessory information service");
+      this.infoAccessory = new this.api.hap.Service.AccessoryInformation();
+      this.accessory.addService(this.infoAccessory);
+    }
 
     this.infoAccessory.setCharacteristic(
       this.api.hap.Characteristic.Manufacturer,
@@ -83,14 +88,18 @@ export class CameraAccessory {
   }
 
   private setupAlarmAccessory() {
-    this.alertService =
-      this.accessory.getServiceById(this.api.hap.Service.Switch, "alarm") ||
-      this.accessory.addService(
-        new this.api.hap.Service.Switch(
-          `${this.accessory.displayName} - Alarm`,
-          "alarm"
-        )
+    this.alertService = this.accessory.getServiceById(
+      this.api.hap.Service.Switch,
+      "alarm"
+    );
+    if (!this.alertService) {
+      this.log.debug("Adding alert service");
+      this.alertService = new this.api.hap.Service.Switch(
+        `${this.accessory.displayName} - Alarm`,
+        "alarm"
       );
+      this.accessory.addService(this.alertService);
+    }
     this.alertService
       .getCharacteristic(this.api.hap.Characteristic.On)
       .onGet(async () => {
@@ -105,14 +114,18 @@ export class CameraAccessory {
   }
 
   private setupPrivacyModeAccessory() {
-    this.privacyService =
-      this.accessory.getServiceById(this.api.hap.Service.Switch, "eyes") ||
-      this.accessory.addService(
-        new this.api.hap.Service.Switch(
-          `${this.accessory.displayName} - Eyes`,
-          "eyes"
-        )
+    this.privacyService = this.accessory.getServiceById(
+      this.api.hap.Service.Switch,
+      "eyes"
+    );
+    if (!this.privacyService) {
+      this.log.debug("Adding privacy service");
+      this.privacyService = new this.api.hap.Service.Switch(
+        `${this.accessory.displayName} - Eyes`,
+        "eyes"
       );
+      this.accessory.addService(this.privacyService);
+    }
     this.privacyService
       .getCharacteristic(this.api.hap.Characteristic.On)
       .onGet(async () => {

--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -65,8 +65,9 @@ export class CameraAccessory {
     );
     if (!this.infoAccessory) {
       this.log.debug("Adding accessory information service");
-      this.infoAccessory = new this.api.hap.Service.AccessoryInformation();
-      this.accessory.addService(this.infoAccessory);
+      this.infoAccessory = this.accessory.addService(
+        this.api.hap.Service.AccessoryInformation
+      );
     }
 
     this.infoAccessory.setCharacteristic(
@@ -88,17 +89,15 @@ export class CameraAccessory {
   }
 
   private setupAlarmAccessory() {
-    this.alertService = this.accessory.getServiceById(
-      this.api.hap.Service.Switch,
-      "alarm"
-    );
+    const name = `${this.accessory.displayName} - Alarm`;
+    this.alertService = this.accessory.getService(name);
     if (!this.alertService) {
       this.log.debug("Adding alert service");
-      this.alertService = new this.api.hap.Service.Switch(
-        `${this.accessory.displayName} - Alarm`,
+      this.alertService = this.accessory.addService(
+        this.api.hap.Service.Switch,
+        name,
         "alarm"
       );
-      this.accessory.addService(this.alertService);
     }
     this.alertService
       .getCharacteristic(this.api.hap.Characteristic.On)
@@ -114,17 +113,15 @@ export class CameraAccessory {
   }
 
   private setupPrivacyModeAccessory() {
-    this.privacyService = this.accessory.getServiceById(
-      this.api.hap.Service.Switch,
-      "eyes"
-    );
+    const name = `${this.accessory.displayName} - Eyes`;
+    this.privacyService = this.accessory.getService(name);
     if (!this.privacyService) {
-      this.log.debug("Adding privacy service");
-      this.privacyService = new this.api.hap.Service.Switch(
-        `${this.accessory.displayName} - Eyes`,
-        "eyes"
+      this.log.debug("Adding alert service");
+      this.privacyService = this.accessory.addService(
+        this.api.hap.Service.Switch,
+        name,
+        "alarm"
       );
-      this.accessory.addService(this.privacyService);
     }
     this.privacyService
       .getCharacteristic(this.api.hap.Characteristic.On)

--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -120,7 +120,7 @@ export class CameraAccessory {
       this.privacyService = this.accessory.addService(
         this.api.hap.Service.Switch,
         name,
-        "alarm"
+        "eyes"
       );
     }
     this.privacyService

--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -8,7 +8,6 @@ import {
 import { StreamingDelegate } from "homebridge-camera-ffmpeg/dist/streamingDelegate";
 import { Logger } from "homebridge-camera-ffmpeg/dist/logger";
 import { TAPOCamera } from "./tapoCamera";
-import { pkg } from "./pkg";
 
 export type CameraConfig = {
   name: string;
@@ -36,16 +35,21 @@ export class CameraAccessory {
   public uuid: string;
   public accessory: PlatformAccessory;
 
-  constructor(log: Logging, config: CameraConfig, api: API) {
+  constructor(
+    log: Logging,
+    config: CameraConfig,
+    api: API,
+    cachedAccessory?: PlatformAccessory
+  ) {
     this.log = log;
     this.config = config;
     this.api = api;
 
     this.uuid = this.api.hap.uuid.generate(this.config.name);
-    this.accessory = new this.api.platformAccessory(
-      this.config.name,
-      this.uuid
-    );
+    this.accessory =
+      cachedAccessory ??
+      new this.api.platformAccessory(this.config.name, this.uuid);
+
     this.tapoCamera = new TAPOCamera(this.log, this.config);
 
     this.setup();

--- a/src/cameraPlatform.ts
+++ b/src/cameraPlatform.ts
@@ -17,7 +17,6 @@ export class CameraPlatform implements DynamicPlatformPlugin {
   private readonly log: Logging;
   private readonly config: CameraPlatformConfig;
   private readonly api: API;
-  private readonly cameraConfigs: Map<string, CameraConfig> = new Map();
 
   constructor(log: Logging, config: PlatformConfig, api: API) {
     this.log = log;
@@ -32,9 +31,7 @@ export class CameraPlatform implements DynamicPlatformPlugin {
 
   didFinishLaunching() {
     this.config.cameras.forEach((cameraConfig) => {
-      const camera = new CameraAccessory(this.log, cameraConfig, this.api);
-      this.api.publishExternalAccessories(pkg.pluginName, [camera.accessory]);
-      this.cameraConfigs.set(camera.uuid, cameraConfig);
+      new CameraAccessory(this.log, cameraConfig, this.api);
     });
   }
 
@@ -44,9 +41,12 @@ export class CameraPlatform implements DynamicPlatformPlugin {
    */
   configureAccessory(accessory: PlatformAccessory): void {
     this.log("Configuring accessory %s", accessory.displayName);
-    const cameraConfig = this.cameraConfigs.get(accessory.UUID);
-    if (cameraConfig) {
-      new CameraAccessory(this.log, cameraConfig, this.api, accessory);
-    }
+    // Won't be called for unbridged accessories
+  }
+
+  removeAccessory(platformAccessory: PlatformAccessory) {
+    this.api.unregisterPlatformAccessories(pkg.pluginName, pkg.name, [
+      platformAccessory,
+    ]);
   }
 }

--- a/src/cameraPlatform.ts
+++ b/src/cameraPlatform.ts
@@ -24,12 +24,17 @@ export class CameraPlatform implements DynamicPlatformPlugin {
     this.config = config as unknown as CameraPlatformConfig;
     this.api = api;
 
-    this.api.on(APIEvent.DID_FINISH_LAUNCHING, () => {
-      this.config.cameras.forEach((cameraConfig) => {
-        const camera = new CameraAccessory(this.log, cameraConfig, this.api);
-        this.api.publishExternalAccessories(pkg.pluginName, [camera.accessory]);
-        this.cameraConfigs.set(camera.uuid, cameraConfig);
-      });
+    this.api.on(
+      APIEvent.DID_FINISH_LAUNCHING,
+      this.didFinishLaunching.bind(this)
+    );
+  }
+
+  didFinishLaunching() {
+    this.config.cameras.forEach((cameraConfig) => {
+      const camera = new CameraAccessory(this.log, cameraConfig, this.api);
+      this.api.publishExternalAccessories(pkg.pluginName, [camera.accessory]);
+      this.cameraConfigs.set(camera.uuid, cameraConfig);
     });
   }
 
@@ -39,5 +44,9 @@ export class CameraPlatform implements DynamicPlatformPlugin {
    */
   configureAccessory(accessory: PlatformAccessory): void {
     this.log("Configuring accessory %s", accessory.displayName);
+    const cameraConfig = this.cameraConfigs.get(accessory.UUID);
+    if (cameraConfig) {
+      new CameraAccessory(this.log, cameraConfig, this.api, accessory);
+    }
   }
 }

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,4 +1,4 @@
 export const pkg = {
   pluginName: "homebridge-tapo-camera",
-  name: "TAPO-CAMERA",
+  name: "tapo-camera",
 };

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,4 +1,4 @@
 export const pkg = {
   pluginName: "homebridge-tapo-camera",
-  name: "tapo-camera",
+  name: "TAPO-CAMERA",
 };


### PR DESCRIPTION
There is a bug that is causing the "privacy" and "alarm" accessories to be reset in automations once Homebridge restarts. This PR fixes that