### PR TITLE
H264 stream doesn't need re-encoding

### DIFF
--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -133,6 +133,8 @@ export class CameraAccessory {
         source: `-i ${streamUrl}`,
         audio: true,
         debug: this.config.videoDebug,
+        vcodec: "copy", // The RSTP stream is H264, so we need to use copy to pass it through
+        videoFilter: "none", // We don't want to filter the video, since we're using copy
       },
     };
     const delegate = new StreamingDelegate(


### PR DESCRIPTION
Following https://github.com/kopiro/homebridge-tapo-camera/issues/7