### PR TITLE
Ensure that the entire homebridge does not go down by setting alarm or privacy when the camera stops responding.

### DIFF
--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -97,7 +97,15 @@ export class CameraAccessory {
       })
       .onSet((status) => {
         this.log.debug(`Setting alarm to ${status ? "on" : "off"}`);
-        this.camera.setAlertConfig(Boolean(status));
+        this.camera.setAlertConfig(Boolean(status))
+          .catch(err => {
+            this.log.error(
+              `[${this.config.name}]`,
+              "Error at 'setAlertConfig'.",
+              err
+            );
+            this.cameraStatus = undefined; // Home.app shows 'No Response'
+          });
       });
   }
 
@@ -120,7 +128,15 @@ export class CameraAccessory {
       })
       .onSet((status) => {
         this.log.debug(`Setting privacy to ${status ? "on" : "off"}`);
-        this.camera.setLensMaskConfig(!status);
+        this.camera.setLensMaskConfig(!status)
+          .catch(err => {
+            this.log.error(
+              `[${this.config.name}]`,
+              "Error at 'setLensMaskConfig'.",
+              err
+            );
+            this.cameraStatus = undefined; // Home.app shows 'No Response'
+          });
       });
   }
 


### PR DESCRIPTION
It was found that the problem occurs when an accessory is operated before it becomes "No Response", so it will be fixed.


sample log:
```
[2/22/2022, 1:23:28 PM] [tapo-camera] [dTapo C100] Error at 'setLensMaskConfig'. FetchError: network timeout at: https://192.168.0.241/stok=xxx/ds
    at Timeout.<anonymous> (/Users/eiryu/ghq/github.com/eiryu/homebridge-tapo-camera/node_modules/node-fetch/lib/index.js:1484:13)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7) {
  type: 'request-timeout'
}
```

related PullRequest (#45)