### PR TITLE
Update URLs pointing to config documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Make your TP-Link TAPO security camera compatible with Homekit through Homebridg
 
 The plugin exposes the camera RTSP video feed, and toggle accessories to configure your automations.
 
-If your video feed is not working, try to check if any of the parameters at the video config can be tuned. You can use [https://sunoo.github.io/homebridge-camera-ffmpeg/configs](https://sunoo.github.io/homebridge-camera-ffmpeg/configs) to check if someone has already found the right values for your camera.
+If your video feed is not working, try to check if any of the parameters at the video config can be tuned. You can use [https://homebridge-plugins.github.io/homebridge-camera-ffmpeg/configs](https://homebridge-plugins.github.io/homebridge-camera-ffmpeg/configs) to check if someone has already found the right values for your camera.
 
 > [!IMPORTANT]
 > ~On firmware build 230921 and higher, [please follow this guide](https://github.com/JurajNyiri/HomeAssistant-Tapo-Control/blob/main/add_camera_with_new_firmware.md) to make your camera compatible with this integration.~

--- a/config.schema.json
+++ b/config.schema.json
@@ -3,7 +3,7 @@
   "pluginType": "platform",
   "singular": true,
   "headerDisplay": "Homebridge plugin for TP-Link TAPO security cameras.",
-  "footerDisplay": "If your video feed is not working, try to check if any of the parameters at the video config can be tuned. You can use https://sunoo.github.io/homebridge-camera-ffmpeg/configs to check if someone has already found the right values for your camera.",
+  "footerDisplay": "If your video feed is not working, try to check if any of the parameters at the video config can be tuned. You can use https://homebridge-plugins.github.io/homebridge-camera-ffmpeg/configs to check if someone has already found the right values for your camera.",
   "form": null,
   "display": null,
   "schema": {


### PR DESCRIPTION
The old URL 404s because the repo changed ownership to a different organization, so the GitHub Pages URL is different. (Unfortunately the documentation is about 3 years old anyway, so it's not terribly helpful for those of us with new cameras.)