### PR TITLE
fix: support newer TAPO firmware auth, camera suspension retry, and streaming defaults

### DIFF
--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -193,15 +193,21 @@ export class CameraAccessory {
     const config: VideoConfig = {
       audio: true, // Set audio as true as most of TAPO cameras have audio
       vcodec: vcodec,
+      // libx264: force Baseline profile and 1s keyframe interval for HomeKit compatibility.
+      ...(vcodec === "libx264" && {
+        encoderOptions: "-preset ultrafast -tune zerolatency -profile:v baseline -level:v 3.1 -g 30",
+      }),
       maxWidth: this.config.videoMaxWidth,
       maxHeight: this.config.videoMaxHeight,
       maxFPS: this.config.videoMaxFPS,
       maxBitrate: this.config.videoMaxBirate,
       packetSize: this.config.videoPacketSize,
       forceMax: this.config.videoForceMax,
+      // async resampling prevents backward audio DTS from pcm_alaw packet jitter.
+      mapaudio: "0:a:0 -af aresample=async=16000",
       ...(this.config.videoConfig || {}),
-      // We add this at the end as the user most not be able to override it
-      source: `-i ${streamUrl}`,
+      // We add this at the end as the user must not be able to override it
+      source: `-rtsp_transport tcp -i ${streamUrl}`,
     };
 
     this.log.debug("Video config", config);

--- a/src/cameraPlatform.ts
+++ b/src/cameraPlatform.ts
@@ -22,17 +22,34 @@ export class CameraPlatform implements IndependentPlatformPlugin {
   }
 
   private discoverDevices() {
-    this.config.cameras?.forEach(async (cameraConfig) => {
-      try {
-        const cameraAccessory = new CameraAccessory(this, cameraConfig);
-        await cameraAccessory.setup();
-      } catch (err) {
-        this.log.error(
-          `Error during setup of camera "${cameraConfig.name}"`,
-          err,
-          err instanceof Error ? err.stack : []
-        );
-      }
+    this.config.cameras?.forEach((cameraConfig) => {
+      this.setupCamera(cameraConfig);
     });
+  }
+
+  private async setupCamera(cameraConfig: CameraConfig, retryAfterSuspension = false): Promise<void> {
+    try {
+      const cameraAccessory = new CameraAccessory(this, cameraConfig);
+      await cameraAccessory.setup();
+    } catch (err) {
+      const suspensionMatch =
+        err instanceof Error &&
+        err.message.match(/Try again in (\d+) seconds/);
+
+      if (suspensionMatch && !retryAfterSuspension) {
+        const seconds = parseInt(suspensionMatch[1], 10);
+        this.log.warn(
+          `Camera "${cameraConfig.name}" is temporarily suspended. Retrying in ${seconds} seconds...`
+        );
+        await new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+        return this.setupCamera(cameraConfig, true);
+      }
+
+      this.log.error(
+        `Error during setup of camera "${cameraConfig.name}"`,
+        err,
+        err instanceof Error ? err.stack : []
+      );
+    }
   }
 }

--- a/src/tapoCamera.ts
+++ b/src/tapoCamera.ts
@@ -46,7 +46,8 @@ export class TAPOCamera extends OnvifCamera {
 
   private readonly hashedPassword: string;
   private readonly hashedSha256Password: string;
-  private passwordEncryptionMethod: "md5" | "sha256" | null = null;
+  private readonly hashedSha1Password: string;
+  private passwordEncryptionMethod: "md5" | "sha256" | "sha1" | null = null;
 
   private isSecureConnectionValue: boolean | null = null;
 
@@ -85,6 +86,11 @@ export class TAPOCamera extends OnvifCamera {
       .update(config.password)
       .digest("hex")
       .toUpperCase();
+    this.hashedSha1Password = crypto
+      .createHash("sha1")
+      .update(config.password)
+      .digest("hex")
+      .toUpperCase();
   }
 
   private getUsername() {
@@ -109,6 +115,8 @@ export class TAPOCamera extends OnvifCamera {
       return this.hashedPassword;
     } else if (this.passwordEncryptionMethod === "sha256") {
       return this.hashedSha256Password;
+    } else if (this.passwordEncryptionMethod === "sha1") {
+      return this.hashedSha1Password;
     } else {
       throw new Error("Unknown password encryption method");
     }
@@ -168,14 +176,25 @@ export class TAPOCamera extends OnvifCamera {
       return true;
     }
 
+    const hashedNoncesWithSHA1 = crypto
+      .createHash("sha1")
+      .update(this.cnonce + this.hashedSha1Password + nonce)
+      .digest("hex")
+      .toUpperCase();
+    if (deviceConfirm === hashedNoncesWithSHA1 + nonce + this.cnonce) {
+      this.passwordEncryptionMethod = "sha1";
+      return true;
+    }
+
     this.log.debug(
-      'Invalid device confirm, expected "sha256" or "md5" to match, but none found',
+      'Invalid device confirm, expected "sha256", "md5", or "sha1" to match, but none found',
       {
         hashedNoncesWithMD5,
         hashedNoncesWithSHA256,
+        hashedNoncesWithSHA1,
         deviceConfirm,
         nonce,
-        cnonce: this,
+        cnonce: this.cnonce,
       }
     );
 
@@ -314,7 +333,8 @@ export class TAPOCamera extends OnvifCamera {
         }
       } else {
         if (
-          responseLoginData.error_code === -40413 &&
+          (responseLoginData.error_code === -40413 ||
+            responseLoginData.error_code === -40211) &&
           loginRetryCount < MAX_LOGIN_RETRIES
         ) {
           this.log.debug(
@@ -338,15 +358,12 @@ export class TAPOCamera extends OnvifCamera {
       responseData = responseLoginData;
     }
 
-    if (
-      responseData.result?.data?.sec_left &&
-      responseData.result.data.sec_left > 0
-    ) {
+    const secLeft =
+      responseData.result?.data?.sec_left ?? responseData.result?.sec_left;
+    if (secLeft && secLeft > 0) {
       this.log.debug("refreshStok: temporary suspension", responseData);
 
-      throw new Error(
-        `Temporary Suspension: Try again in ${responseData.result.data.sec_left} seconds`
-      );
+      throw new Error(`Temporary Suspension: Try again in ${secLeft} seconds`);
     }
 
     if (
@@ -379,7 +396,7 @@ export class TAPOCamera extends OnvifCamera {
       return this.refreshStok(loginRetryCount + 1);
     }
 
-    this.log.debug("refreshStock: Unexpected end of flow, raising exception");
+    this.log.debug("refreshStok: Unexpected end of flow, raising exception");
     throw new Error("Invalid authentication data");
   }
 
@@ -405,16 +422,19 @@ export class TAPOCamera extends OnvifCamera {
         JSON.stringify(responseData)
       );
 
+      const errCode = responseData?.error_code;
       this.isSecureConnectionValue =
-        responseData?.error_code == -40413 &&
-        String(responseData.result?.data?.encrypt_type || "")?.includes("3");
+        // -40211 = newer firmware requires cnonce in request (probe doesn't send it)
+        errCode == -40211 ||
+        (errCode == -40413 &&
+          String(responseData.result?.data?.encrypt_type || "")?.includes("3"));
     }
 
     return this.isSecureConnectionValue;
   }
 
   getStok(loginRetryCount = 0): Promise<string> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       if (this.stok) {
         return resolve(this.stok);
       }
@@ -430,6 +450,7 @@ export class TAPOCamera extends OnvifCamera {
           }
           resolve(this.stok!);
         })
+        .catch(reject)
         .finally(() => {
           this.stokPromise = undefined;
         });

--- a/src/types/tapo.ts
+++ b/src/types/tapo.ts
@@ -277,6 +277,7 @@ export type TAPOCameraRefreshStokResponse = {
     start_seq?: number;
     user_group?: string;
     stok?: string;
+    sec_left?: number;
     data?: {
       code?: number;
       nonce?: string;


### PR DESCRIPTION
Hi @kopiro 👋

I've been running this plugin for a while and recently hit a wall when my C200 cameras updated to firmware 1.4.4. Auth broke completely, and debugging it led me down a rabbit hole that turned up a few related issues. I've seen the same problems reported by a number of other users in the issue tracker, so I wanted to put together a fix that could help everyone.

I've kept the changes as minimal and focused as possible: three independent commits, each fixing one thing. Happy to split them into separate PRs if that's easier to review, adjust anything based on your feedback, or drop anything that's not the right fit. 

Hope all is well and you're having a nice end to your week. Thank you for this plugin, it's been great!

---

## Summary

This PR fixes three distinct bugs that together make the plugin unusable with newer TAPO camera firmware. Each commit is self-contained.

All three changes are backward compatible. The new auth paths (SHA1, -40211) are only reached if the existing SHA256/MD5/-40413 checks fail first. The streaming defaults are applied on the Homebridge side and are unaffected by firmware version. Tested on C200 firmware 1.4.4 (newer auth path) and verified that the existing code paths for older firmware are untouched.

---

### 1. Support newer TAPO firmware authentication

**Files:** `src/tapoCamera.ts`, `src/types/tapo.ts`

Newer TAPO firmware (C200, C110, C210 -- reported widely in #207, #182, #177, #168, #163) changed the secure auth handshake in two ways that break the plugin:

- The initial challenge now returns error code `-40211` instead of `-40413`. The plugin only recognised `-40413` as "use secure connection", so newer firmware fell through to the wrong path.
- The `device_confirm` value is now computed with SHA1 instead of the SHA256/MD5 variants the plugin already handles. The plugin tried all known formats and fell through to "Invalid device confirm".

Additionally, the suspension timer (returned when too many failed logins lock the camera out) is at `result.sec_left` on newer firmware but at `result.data.sec_left` on older firmware. Reading only the older path caused an unhandled-rejection crash instead of a clean error message, which in turn triggered an immediate retry and deepened the suspension.

**Changes:**
- Accept `-40211` as the "use secure connection" signal alongside `-40413`
- Add SHA1 `device_confirm` variant: `SHA1(cnonce + hashedSha1Password + nonce).toUpperCase()`
- Try SHA256, MD5, and SHA1 in sequence during `validateDeviceConfirm`
- Retry on `-40211` during the cnonce-based login exchange, same as `-40413`
- Read `sec_left` from both `result.sec_left` (newer) and `result.data.sec_left` (older)
- Fix unhandled promise rejection in `getStok` under suspension conditions
- Fix `cnonce` debug log typo (`cnonce: this` -> `this.cnonce`); add SHA1 hash to debug output
- Fix log typo: "refreshStock" -> "refreshStok"

Closes #207. Also resolves the underlying cause reported in #182, #177, #168, #163.

---

### 2. Wait out camera suspension on startup instead of failing

**File:** `src/cameraPlatform.ts`

When a camera is temporarily suspended (too many failed login attempts), the previous code threw immediately and left the accessory permanently broken for the Homebridge session. Because Homebridge or child-bridge restarts would retry immediately, this worsened the suspension -- a restart loop is the worst-case scenario for a camera lockout (#188).

If `setup()` throws a message matching `"Try again in N seconds"`, the platform now waits the indicated number of seconds then retries setup once. This respects the camera's back-off window and recovers without manual intervention.

Closes #188.

---

### 3. Improve default streaming config for HomeKit compatibility

**File:** `src/cameraAccessory.ts`

Two ffmpeg defaults caused streams to fail silently in HomeKit (#133, #127):

**TCP transport** (`-rtsp_transport tcp`): the previous default left RTSP data on UDP. On Wi-Fi with any packet loss, UDP causes stream stalls and ffmpeg drops frames silently. TCP retransmits keep the stream alive.

**Audio DTS jitter** (`aresample=async=16000`): TAPO cameras deliver pcm_alaw audio in 20 ms bursts with irregular timing. Two back-to-back packets 5 ms apart produce a backward decode timestamp, causing `libfdk_aac` to emit "Queue input is backward in time" and eventually drop audio entirely. The `aresample=async=16000` filter absorbs this jitter by inserting or dropping up to 1 s/s of samples, keeping DTS monotonically increasing without audible artefacts.

**libx264 defaults** (only when `videoCodec: "libx264"` is configured): libx264's default GOP is 250 frames (~8 s at 30 fps), which makes HomeKit display the loading spinner until an RTCP timeout forces a keyframe request. This adds sensible explicit defaults -- Baseline profile, level 3.1, 1 s keyframe interval -- when the user opts in to software re-encoding.

Partially addresses #133, #127.