### PR TITLE
fix: use permissive ALL:@SECLEVEL=0 ciphers to fix firmware 1.6.3 compatibility

### DIFF
--- a/src/tapoCamera.ts
+++ b/src/tapoCamera.ts
@@ -72,7 +72,7 @@ export class TAPOCamera extends OnvifCamera {
       connect: {
         // TAPO devices have self-signed certificates
         rejectUnauthorized: false,
-        ciphers: "AES256-SHA:AES128-GCM-SHA256",
+        ciphers: "ALL:@SECLEVEL=0",
       },
     });
 


### PR DESCRIPTION
Fixes #212

## Context
Tapo cameras, specifically the C320WS on firmware 1.6.3 (and likely others moving forward), have dropped support for older SSL/TLS cipher suites (like `AES256-SHA`). Because `homebridge-tapo-camera` explicitly restricted its TLS connections to `AES256-SHA:AES128-GCM-SHA256`, the handshake with these newer firmwares was failing with `SSL routines:ssl3_read_bytes:ssl/tls alert handshake failure`.

## Changes
This PR updates the `fetchAgent` cipher configuration in `tapoCamera.ts` to `"ALL:@SECLEVEL=0"`. 

This follows the same permissive approach used by `pytapo` and `homeassistant-tapo-control`. It allows OpenSSL to negotiate using modern secure ciphers with newer devices, while seamlessly lowering the security level floor to support legacy ciphers strictly required by older Tapo firmwares.
