### PR TITLE
Support controls-only camera setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,27 @@ npm -g install homebridge-tapo-camera
 
 It is highly recommended that you use either Homebridge Config UI X or the HOOBS UI to install and configure this plugin.
 
+#### Expose only switches and sensors
+
+If your camera is already paired with HomeKit natively, you can use this plugin only for the TAPO controls that native HomeKit does not expose.
+
+Set `disableStreaming` to `true` to skip the Homebridge camera stream while keeping the toggle accessories. If you also do not want the ONVIF motion sensor, set `disableMotionSensorAccessory` to `true`; in that setup, `streamUser` and `streamPassword` are not required.
+
+```json
+{
+  "name": "My Camera Controls",
+  "ipAddress": "192.168.0.XXX",
+  "password": "your-tapo-password",
+  "disableStreaming": true,
+  "disableMotionSensorAccessory": true
+}
+```
+
+To keep the ONVIF motion sensor enabled, provide `streamUser` and `streamPassword` from the TAPO app camera account.
+
 ### FFmpeg installation
 
 The plugin should take care of installing the `ffmpeg` automatically.
 
 > [!IMPORTANT]  
 > If you're getting errors like `FFmpeg exited with code: 1 and signal: null (Error)`, please follow the instructions here on how to install [ffmpeg-for-homebridge](https://github.com/homebridge/ffmpeg-for-homebridge) binaries manually.
-

--- a/config.schema.json
+++ b/config.schema.json
@@ -41,15 +41,13 @@
           "streamUser": {
             "title": "Stream User",
             "type": "string",
-            "required": true,
-            "description": "Username to access the RTSP video feed (You can find them in TAPO app > Settings > Advanced Settings > Camera Account) - Note: This must be only alphanumeric [A-Za-z0-9], no special characters allowed!",
+            "description": "Username to access the RTSP video feed and ONVIF motion sensor (You can find it in TAPO app > Settings > Advanced Settings > Camera Account). Required unless both streaming and the motion sensor are disabled. Note: This must be only alphanumeric [A-Za-z0-9], no special characters allowed!",
             "placeholder": "user"
           },
           "streamPassword": {
             "title": "Stream Password",
             "type": "string",
-            "required": true,
-            "description": "Password to access the RTSP video feed (You can find them in TAPO app > Settings > Advanced Settings > Camera Account) - Note: This must be only alphanumeric [A-Za-z0-9], no special characters allowed!"
+            "description": "Password to access the RTSP video feed and ONVIF motion sensor (You can find it in TAPO app > Settings > Advanced Settings > Camera Account). Required unless both streaming and the motion sensor are disabled. Note: This must be only alphanumeric [A-Za-z0-9], no special characters allowed!"
           },
           "pullInterval": {
             "title": "Pull Interval",

--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -18,8 +18,8 @@ export type CameraConfig = {
   ipAddress: string;
   username: string;
   password: string;
-  streamUser: string;
-  streamPassword: string;
+  streamUser?: string;
+  streamPassword?: string;
 
   pullInterval?: number;
   disableStreaming?: boolean;
@@ -87,6 +87,16 @@ export class CameraAccessory {
       this.api.hap.Categories.CAMERA
     );
     this.camera = new TAPOCamera(this.log, this.config);
+  }
+
+  private hasStreamCredentials() {
+    return Boolean(this.config.streamUser && this.config.streamPassword);
+  }
+
+  private isMotionSensorEnabled() {
+    return (
+      !this.config.disableMotionSensorAccessory && this.hasStreamCredentials()
+    );
   }
 
   private setupInfoAccessory(basicInfo: TAPOBasicInfo) {
@@ -225,6 +235,13 @@ export class CameraAccessory {
 
   private async setupCameraStreaming(basicInfo: TAPOBasicInfo) {
     try {
+      if (!this.hasStreamCredentials()) {
+        this.log.error(
+          "Camera streaming requires streamUser and streamPassword. Set disableStreaming to true for controls-only setups."
+        );
+        return;
+      }
+
       const delegate = new StreamingDelegate(
         new Logger(this.log),
         {
@@ -250,6 +267,13 @@ export class CameraAccessory {
 
   private async setupMotionSensorAccessory() {
     try {
+      if (!this.hasStreamCredentials()) {
+        this.log.warn(
+          "Motion sensor requires streamUser and streamPassword. Skipping motion sensor setup."
+        );
+        return;
+      }
+
       this.motionSensorService = this.accessory.addService(
         this.platform.api.hap.Service.MotionSensor,
         "Motion Sensor",
@@ -295,11 +319,10 @@ export class CameraAccessory {
       
       if (
         this.isOffline ||
-        (!this.config.disableMotionSensorAccessory &&
-          !this.camera.onvifConnected)
+        (this.isMotionSensorEnabled() && !this.camera.onvifConnected)
       ) {
         let onvifSuccess = true;
-        if (!this.config.disableMotionSensorAccessory) {
+        if (this.isMotionSensorEnabled()) {
           this.log.info(
             "Camera is back online, restarting ONVIF connection..."
           );


### PR DESCRIPTION
## Summary
- allow controls-only camera configs without RTSP credentials when streaming and motion sensor are disabled
- skip streaming and ONVIF setup cleanly when stream credentials are missing
- document the native HomeKit camera + Homebridge controls setup

## Verification
- npm run build
- npm run lint

Fixes #172