### PR TITLE
Fix videoMaxBitrate config option never applying (schema/code spelling mismatch)

### DIFF
--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -37,6 +37,8 @@ export type CameraConfig = {
   videoMaxHeight?: number;
   videoMaxFPS?: number;
   videoForceMax?: boolean;
+  videoMaxBitrate?: number;
+  /** @deprecated misspelling of videoMaxBitrate, kept for configs that used it */
   videoMaxBirate?: number;
   videoPacketSize?: number;
   videoCodec?: string;
@@ -218,7 +220,7 @@ export class CameraAccessory {
       maxWidth: this.config.videoMaxWidth,
       maxHeight: this.config.videoMaxHeight,
       maxFPS: this.config.videoMaxFPS,
-      maxBitrate: this.config.videoMaxBirate,
+      maxBitrate: this.config.videoMaxBitrate ?? this.config.videoMaxBirate,
       packetSize: this.config.videoPacketSize,
       forceMax: this.config.videoForceMax,
       // async resampling prevents backward audio DTS from pcm_alaw packet jitter.


### PR DESCRIPTION
## Problem

`config.schema.json` declares the option as **`videoMaxBitrate`** — which is what the Homebridge UI writes to `config.json`:

https://github.com/kopiro/homebridge-tapo-camera/blob/7754d60/config.schema.json#L167

…but the code reads **`config.videoMaxBirate`** (missing "t"):

https://github.com/kopiro/homebridge-tapo-camera/blob/7754d60/src/cameraAccessory.ts#L40
https://github.com/kopiro/homebridge-tapo-camera/blob/7754d60/src/cameraAccessory.ts#L221

So a bitrate cap configured through the UI silently never reaches `homebridge-camera-ffmpeg` (relevant when `videoCodec` is set to `libx264` — the default `copy` ignores bitrate anyway).

## Fix

Read `videoMaxBitrate` (matching the schema) and keep the misspelled key as a deprecated fallback, so any hand-written configs that used `videoMaxBirate` keep working.

`npm run lint` and `npm run build` pass.