### PR TITLE
Automate npm and GitHub releases from main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,23 +1,56 @@
-name: Publish Package to npmjs
+name: Release package
 
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
-  
 on:
   push:
-    tags:
-      - 'v*'
-      
+    branches:
+      - main
+
+# A release writes its version commit and tag back to main. Keeping one release in
+# flight prevents two closely spaced merges from choosing the same npm version.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
-  build:
+  release:
+    # Commits pushed with GITHUB_TOKEN do not normally start another workflow,
+    # but the explicit guard protects the invariant if GitHub changes that rule.
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm run build --if-present
-      - run: npm publish
+
+      - name: Create patch version
+        id: version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # The release commit remains in the repository so package.json, the npm
+          # artifact, the Git tag, and the GitHub Release always describe one version.
+          npm version patch -m "chore: release v%s [skip ci]"
+          echo "tag=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Push version commit and tag
+        run: git push origin HEAD:main --follow-tags
+
+      - name: Publish to npm
+        run: npm publish
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: gh release create "$RELEASE_TAG" --verify-tag --generate-notes --title "$RELEASE_TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,5 @@
 
 ## Development & Publishing
 - The project is written in TypeScript and uses `npm`.
-- **Publishing to npm:** Do NOT run `npm publish` locally. The project uses a GitHub Actions workflow (`.github/workflows/publish.yml`) that automatically publishes to npm via OIDC when a new version tag (e.g., `v2.9.0`) is pushed to GitHub. 
-- To release a new version, simply use `npm version <major|minor|patch>` and push the resulting commit and tag to GitHub (`git push --follow-tags`).
+- **Publishing to npm:** Do NOT run `npm publish` locally. Every non-automation commit pushed to `main` runs `.github/workflows/publish.yml`, which increments the patch version, publishes to npm through OIDC, pushes the version commit and tag, and creates a GitHub Release with generated notes.
+- The workflow's own `chore: release` commit is intentionally excluded from starting another release.


### PR DESCRIPTION
## What changed

- run the release workflow for commits pushed to `main`
- serialize releases and increment the patch version automatically
- push the generated version commit and tag
- publish the package to npm through the existing OIDC setup
- create a GitHub Release with generated release notes
- document the new release process in `AGENTS.md`

## Why

Merging a change to `main` previously did not publish anything because the workflow only reacted to manually created `v*` tags. The automated version commit keeps `package.json`, npm, the Git tag, and the GitHub Release aligned while the actor guard and `[skip ci]` prevent recursive releases.

## Validation

- `git diff --check`
- parsed `.github/workflows/publish.yml` as YAML
- confirmed repository workflow permissions default to `write`
- confirmed `main` branch protection does not restrict workflow pushes
