### PR TITLE
Fix floodlight control method

### DIFF
--- a/src/tapoCamera.ts
+++ b/src/tapoCamera.ts
@@ -690,7 +690,10 @@ export class TAPOCamera extends OnvifCamera {
       },
     }),
     floodLight: (value) => ({
-      method: "setLdc",
+      // Floodlight state belongs to the white-lamp API. setLdc controls lens
+      // distortion correction, so using it here accepts the request shape in
+      // TypeScript but leaves the physical light unchanged on the camera.
+      method: "setWhitelampConfig",
       params: {
         image: {
           switch: {

--- a/src/types/tapo.ts
+++ b/src/types/tapo.ts
@@ -137,16 +137,6 @@ export type TAPOCameraSetRequest =
           };
         };
       };
-    }
-  | {
-      method: "setLdc";
-      params: {
-        image: {
-          switch: {
-            force_wtl_state: "on" | "off";
-          };
-        };
-      };
     };
 
 export type TAPOCameraUnencryptedRequest = {


### PR DESCRIPTION
## What changed

- send floodlight state through `setWhitelampConfig`
- remove the incorrect internal `setLdc` request shape

## Why

The floodlight accessory added for #166 queried state through the white-lamp API but attempted to change state through `setLdc`, which controls lens distortion correction. The request therefore did not control the physical light even though its payload looked like a white-lamp request.

Removing the misleading `setLdc` request type also prevents this incorrect method/payload combination from type-checking again.

Closes #166.

## Validation

- clean install under Node 24
- `npm run lint`
- `npm run build`
- `git diff --check`
