### PR TITLE
Make RTSP transport configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Set `disableStreaming` to `true` to skip the Homebridge camera stream while keep
 
 To keep the ONVIF motion sensor enabled, provide `streamUser` and `streamPassword` from the TAPO app camera account.
 
+#### RTSP transport
+
+Camera streams use UDP by default. Set `rtspTransport` to `"tcp"` for a camera if UDP is unreliable on your network.
+
+```json
+{
+  "name": "My Camera",
+  "rtspTransport": "tcp"
+}
+```
+
 ### FFmpeg installation
 
 The plugin should take care of installing the `ffmpeg` automatically.

--- a/config.schema.json
+++ b/config.schema.json
@@ -105,6 +105,16 @@
             "type": "boolean",
             "description": "Video stream will be requested in low-quality instead of high-quality"
           },
+          "rtspTransport": {
+            "title": "RTSP Transport",
+            "type": "string",
+            "default": "udp",
+            "enum": [
+              "udp",
+              "tcp"
+            ],
+            "description": "Transport protocol used to receive the camera RTSP stream. UDP is the default; try TCP if UDP is unreliable on your network."
+          },
           "eyesToggleAccessoryName": {
             "title": "Eyes (privacy mode) toggle Name",
             "type": "string",

--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -32,6 +32,7 @@ export type CameraConfig = {
 
   disableMotionSensorAccessory?: boolean;
   lowQuality?: boolean;
+  rtspTransport?: "udp" | "tcp";
 
   videoMaxWidth?: number;
   videoMaxHeight?: number;
@@ -227,7 +228,7 @@ export class CameraAccessory {
       mapaudio: "0:a:0 -af aresample=async=16000",
       ...(this.config.videoConfig || {}),
       // We add this at the end as the user must not be able to override it
-      source: `-rtsp_transport tcp -i ${streamUrl}`,
+      source: `-rtsp_transport ${this.config.rtspTransport ?? "udp"} -i ${streamUrl}`,
     };
 
     this.log.debug("Video config", config);


### PR DESCRIPTION
## Summary

- add a per-camera `rtspTransport` option supporting `udp` and `tcp`
- use UDP when the option is absent
- expose the option in the Homebridge configuration schema and document it

## Why

TCP transport has caused severe frame dropping for some TAPO cameras since it became mandatory in 2.7.0. UDP restores the pre-2.7.0 behavior while retaining TCP as an explicit option for networks where it works better.

Closes #227

## Validation

- `node -e 'JSON.parse(require("fs").readFileSync("config.schema.json", "utf8"))'`
- `npm run lint`
- `npm run build`
- `git diff --check`